### PR TITLE
use fixed config_file for test

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,6 @@ import os
 # Inject mandatory environment variables
 
 env_settings = [
-    ('CONFIG_FILE', 'data/test_omnibot_config.yaml'),
     ('CREDENTIALS_SLACK_VERIFICATION_TOKEN_A12345678', '1234'),
     ('CREDENTIALS_SLACK_OAUTH_TOKEN_A12345678', '1234'),
     ('CREDENTIALS_SLACK_OAUTH_BOT_TOKEN_A12345678', '1234'),
@@ -29,5 +28,6 @@ env_settings = [
     ('CREDENTIALS_SLACK_VERIFICATION_TOKEN_A99999999', '1234'),
 ]
 
+os.environ['CONFIG_FILE'] = 'data/test_omnibot_config.yaml'
 for env_setting in env_settings:
     os.environ[env_setting[0]] = os.getenv(env_setting[0], env_setting[1])


### PR DESCRIPTION
Moving the env override for test init to always use the yaml content.