### PR TITLE
Add logging of callback dict in handler logs

### DIFF
--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -372,7 +372,7 @@ def _handle_message_callback(message, callback):
             message.match_type,
             message.match
         ),
-        extra=message.event_trace
+        extra={**message.event_trace, 'callback': callback},
     )
     response = _handle_callback(message, callback)
     for action in response.get('actions', []):
@@ -397,7 +397,7 @@ def _handle_slash_command_callback(command, callback, response_type):
         'Handling callback for slash_command: command="{}"'.format(
             command.command
         ),
-        extra=command.event_trace
+        extra={**command.event_trace, 'callback': callback},
     )
     response = _handle_callback(command, callback)
     for command_response in response.get('responses', []):
@@ -447,7 +447,7 @@ def _handle_slash_command_callback(command, callback, response_type):
 def _handle_interactive_component_callback(component, callback, response_type):
     logger.info(
         'Handling callback for interactive component',
-        extra=component.event_trace,
+        extra={**component.event_trace, 'callback': callback},
     )
     response = _handle_callback(component, callback)
     for component_response in response.get('responses', []):


### PR DESCRIPTION
Useful for debugging when we want to see which callback was issued by a specific message event in a single log entry.

e.g.
```jsonc
{
   "ts":"2021-02-02T19:02:50.378Z",
   "name":"omnibot.processor",
   "lvlname":"INFO",
   "kv":{
      // ...
      "callback":{ // new key in kv
         "module":"omnibot.callbacks.message_callbacks:help_callback"
      }
   },
   "msg":"Handling callback for message: match_type=\"command\" match=\"help\""
}
```