### PR TITLE
add channel info in action failed log

### DIFF
--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -743,7 +743,7 @@ def _perform_action(bot, data):
                         ret
                     ),
                     extra=merge_logging_context(
-                        {'action': action},
+                        {'action': action, 'kwargs': kwargs},
                         bot.logging_context,
                     ),
                 )
@@ -753,7 +753,7 @@ def _perform_action(bot, data):
                     ret
                 ),
                 extra=merge_logging_context(
-                    {'action': action},
+                    {'action': action, 'kwargs': kwargs},
                     bot.logging_context,
                 ),
             )


### PR DESCRIPTION
Adding channel info (in kwargs) for more actionable log in `_perform_action`.