### PR TITLE
Fix mention extraction when parsing message for non-breaking space characters sent by Slack

### DIFF
--- a/omnibot/services/slack/parser.py
+++ b/omnibot/services/slack/parser.py
@@ -3,6 +3,8 @@ import re
 from omnibot.services import slack
 from omnibot.services import stats
 
+SPACE_REGEX = re.compile(r'[\s\u00A0]')
+
 
 def extract_users(text, bot):
     statsd = stats.get_statsd_client()
@@ -178,7 +180,7 @@ def extract_mentions(text, bot, channel):
     with statsd.timer('parser.extract_mentions'):
         to_me = False
         at_me = '@{}'.format(bot.name)
-        if text.split(' ')[0] == at_me:
+        if SPACE_REGEX.split(text)[0] == at_me:
             to_me = True
         directed = channel.get('is_im') or to_me
         return directed

--- a/tests/unit/omnibot/services/slack/parser_test.py
+++ b/tests/unit/omnibot/services/slack/parser_test.py
@@ -1,11 +1,21 @@
-from omnibot.services.slack.parser import extract_users
+from omnibot.services.slack.parser import extract_users, extract_mentions
 
 
 def test_extract_user():
-    assert extract_users("<@W024BE7LH|logan-smith>", "ball") == {'<@W024BE7LH|logan-smith>': 'logan-smith'}
-    assert extract_users("<@U024BE7LH|logan-smith>", "ball") == {'<@U024BE7LH|logan-smith>': 'logan-smith'}
+    assert extract_users("<@W024BE7LH|logan-smith>", "ball") == {
+        '<@W024BE7LH|logan-smith>': 'logan-smith'}
+    assert extract_users("<@U024BE7LH|logan-smith>", "ball") == {
+        '<@U024BE7LH|logan-smith>': 'logan-smith'}
 
 
 # we do not support G so nothing should be returned
 def test_not_supported_extract():
     assert extract_users("<@G024BE7LH|logan-smith>", "ball") == {}
+
+
+def test_extract_mentions(mocker):
+    mock_bot = mocker.patch('omnibot.services.slack.bot.Bot')
+    mock_bot.return_value.name = 'omnibot'
+    assert extract_mentions('@omnibot testcommand', mock_bot.return_value, {})
+    assert extract_mentions('@omnibot\u00A0testcommand', mock_bot.return_value, {})
+    assert not extract_mentions('@omnibottestcommand', mock_bot.return_value, {})


### PR DESCRIPTION
When a user copy-and-pastes a command into Slack and hits enter, for some reason Slack sends the event payload with non-breaking space characters (unicode `\u00A0`), which causes omnibot to not detect a `directed` bot user in these cases and hence will not forward the even payload to the corresponding downstream bot.

e.g. raw text payloads:

1. `{"text": "@bot-name command"}` -> omnibot knows this text payload is targeting a bot with the name `bot-name`
2. `{"text": "@bot-name\u00A0command"}` -> omnibot does not know this text payload is targeting a bot because the original logic for setting `directed = True` is when `text.split(' ')[0] == bot name`, which in this case there is no `' '` char to split by because Slack sent us a non-breaking space character instead.

This change allows for any whitespace character to be between the @bot-mention and the start of the command for forwarding the payload downstream.

**NOTE that Slack has acknowledged this issue as a bug but is unsure when this will be fixed by them upstream.**