### PR TITLE
processor: info log has the potential to leak credentials

### DIFF
--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -370,6 +370,7 @@ def _handle_message_callback(message, callback):
             message.match_type,
             message.match
         ),
+        extra={**message.event_trace},
     )
     response = _handle_callback(message, callback)
     for action in response.get('actions', []):

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -370,7 +370,12 @@ def _handle_message_callback(message, callback):
             message.match_type,
             message.match
         ),
-        extra={**message.event_trace},
+        extra={
+            **message.event_trace,
+            'module': callback['module'],
+            'request_kwargs': callback.get('kwargs', {}).get('request_kwargs', {}),
+            'client_kwargs': callback.get('kwargs', {}).get('client_kwargs', {}).get('service', ""),
+        },
     )
     response = _handle_callback(message, callback)
     for action in response.get('actions', []):

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -370,7 +370,6 @@ def _handle_message_callback(message, callback):
             message.match_type,
             message.match
         ),
-        extra={**message.event_trace, 'callback': callback},
     )
     response = _handle_callback(message, callback)
     for action in response.get('actions', []):


### PR DESCRIPTION
For one of the internal bots, a change was made in the internal config that allows for authentication info to be passed in the message handler's network callback. This info log leaks the credentials.