### PR TITLE
Add more jailed tests for omnibot endpoints

### DIFF
--- a/data/test_omnibot_config.yaml
+++ b/data/test_omnibot_config.yaml
@@ -13,6 +13,7 @@ authorization:
           - "/api/v1/slack/send_im/.*"
           # Set one very specific route, so we can test a failure case
           - "/api/v2/slack/action/test2ndteam/pingbot"
+          - "/api/v2/slack/action/test-team-name/TEST_OMNIBOT_NAME"
     - module: "omnibot.authnz.envoy_checks:envoy_internal_check"
     - module: "omnibot.authnz.envoy_checks:envoy_permissions_check"
   permissions:
@@ -43,6 +44,7 @@ authorization:
         - "POST"
       paths:
         - "/api/v1/slack/send_im/test-team-name/TEST_OMNIBOT_NAME/.*"
+        - "/api/v2/slack/action/test-team-name/TEST_OMNIBOT_NAME"
     pingbot_slack_action:
       methods:
         - "POST"

--- a/data/test_omnibot_config.yaml
+++ b/data/test_omnibot_config.yaml
@@ -31,6 +31,7 @@ authorization:
         - "/api/v1/slack/get_team/test-team-name"
         - "/api/v1/slack/get_team/test-invalid-team-name"
         - "/api/v1/slack/get_user/test-team-name/TEST_OMNIBOT_NAME/.*"
+        - "/api/v1/slack/get_channel/test-team-name/TEST_OMNIBOT_NAME/test-channel"
         - "/api/v1/slack/get_team/testteam"
         - "/api/v1/slack/get_user/testteam/echobot/.*"
         - "/api/v1/slack/get_channel/testteam/echobot/.*"

--- a/data/test_omnibot_config.yaml
+++ b/data/test_omnibot_config.yaml
@@ -28,6 +28,9 @@ authorization:
       methods:
         - "GET"
       paths:
+        - "/api/v1/slack/get_team/test-team-name"
+        - "/api/v1/slack/get_team/test-invalid-team-name"
+        - "/api/v1/slack/get_user/test-team-name/TEST_OMNIBOT_NAME/.*"
         - "/api/v1/slack/get_team/testteam"
         - "/api/v1/slack/get_user/testteam/echobot/.*"
         - "/api/v1/slack/get_channel/testteam/echobot/.*"

--- a/data/test_omnibot_config.yaml
+++ b/data/test_omnibot_config.yaml
@@ -32,11 +32,17 @@ authorization:
         - "/api/v1/slack/get_team/test-invalid-team-name"
         - "/api/v1/slack/get_user/test-team-name/TEST_OMNIBOT_NAME/.*"
         - "/api/v1/slack/get_channel/test-team-name/TEST_OMNIBOT_NAME/test-channel"
+        - "/api/v1/slack/get_ims/test-team-name/TEST_OMNIBOT_NAME"
         - "/api/v1/slack/get_team/testteam"
         - "/api/v1/slack/get_user/testteam/echobot/.*"
         - "/api/v1/slack/get_channel/testteam/echobot/.*"
         - "/api/v1/slack/get_ims/testteam/echobot"
         - "/api/v1/slack/send_im/testteam/echobot/.*"
+    omnibot_write:
+      methods:
+        - "POST"
+      paths:
+        - "/api/v1/slack/send_im/test-team-name/TEST_OMNIBOT_NAME/.*"
     pingbot_slack_action:
       methods:
         - "POST"
@@ -47,6 +53,7 @@ authorization:
       - "slack_api"
     "someservice":
       - "omnibot_read_only"
+      - "omnibot_write"
     "service.*":
       - "pingbot_slack_action"
 help_handler: "omnibot.handlers.message_handlers:help_handler"

--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -634,7 +634,7 @@ def get_channel_by_name(team_name, bot_name, channel_name):
              "last_set": 1507156612
            },
            "purpose": {
-             "value": "This channel is for team-wide communication."
+             "value": "This channel is for team-wide communication.",
              "creator": "",
              "last_set": 0
            },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,8 @@
 import os
 from unittest.mock import MagicMock
 
-import boto3
 import pytest
 from flask import testing
-from moto import mock_sqs
 from pytest_mock import MockerFixture
 from werkzeug.datastructures import Headers
 from werkzeug.test import Client
@@ -57,9 +55,3 @@ def aws_credentials():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
-
-
-@pytest.fixture(scope="function")
-def s3(aws_credentials):
-    with mock_sqs():
-        yield boto3.client("s3", region_name="us-east-1")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from flask import testing
 from pytest_mock import MockerFixture
+from slackclient import SlackClient
 from werkzeug.datastructures import Headers
 from werkzeug.test import Client
 
@@ -78,10 +79,6 @@ def queue(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("omnibot.routes.api.queue_event")
 
 
-@pytest.fixture(scope="function")
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+@pytest.fixture
+def slack_api_call(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(SlackClient, "api_call")

--- a/tests/integration/routes/test_get_channel.py
+++ b/tests/integration/routes/test_get_channel.py
@@ -1,0 +1,24 @@
+from flask import Response  # noqa: F401
+from pytest_mock import MockerFixture
+from werkzeug.test import Client
+
+
+def test_get_channel_by_name(internal_client: Client, mocker: MockerFixture):
+    get_channel_by_name = mocker.patch("omnibot.services.slack.get_channel_by_name")
+    mock_channel_value = {"channel": {"id": "test-channel-id"}}
+    get_channel_by_name.return_value = mock_channel_value
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_channel/test-team-name/TEST_OMNIBOT_NAME/test-channel"
+    )
+    assert resp.status_code == 200
+    assert resp.json == mock_channel_value
+
+
+def test_get_channel_by_name_invalid(internal_client: Client, mocker: MockerFixture):
+    get_channel_by_name = mocker.patch("omnibot.services.slack.get_channel_by_name")
+    get_channel_by_name.return_value = None
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_channel/test-team-name/TEST_OMNIBOT_NAME/test-channel"
+    )
+    assert resp.status_code == 404
+    assert resp.json["error"] == "provided channel_name was not found."

--- a/tests/integration/routes/test_get_channel.py
+++ b/tests/integration/routes/test_get_channel.py
@@ -2,6 +2,8 @@ from flask import Response  # noqa: F401
 from pytest_mock import MockerFixture
 from werkzeug.test import Client
 
+from tests.integration.routes import get_test_bot
+
 
 def test_get_channel_by_name(internal_client: Client, mocker: MockerFixture):
     get_channel_by_name = mocker.patch("omnibot.services.slack.get_channel_by_name")
@@ -12,6 +14,7 @@ def test_get_channel_by_name(internal_client: Client, mocker: MockerFixture):
     )
     assert resp.status_code == 200
     assert resp.json == mock_channel_value
+    get_channel_by_name.assert_called_once_with(get_test_bot(), "test-channel")
 
 
 def test_get_channel_by_name_invalid(internal_client: Client, mocker: MockerFixture):
@@ -22,3 +25,4 @@ def test_get_channel_by_name_invalid(internal_client: Client, mocker: MockerFixt
     )
     assert resp.status_code == 404
     assert resp.json["error"] == "provided channel_name was not found."
+    get_channel_by_name.assert_called_once_with(get_test_bot(), "test-channel")

--- a/tests/integration/routes/test_get_ims.py
+++ b/tests/integration/routes/test_get_ims.py
@@ -4,6 +4,8 @@ from flask import Response  # noqa: F401
 from pytest_mock import MockerFixture
 from werkzeug.test import Client
 
+from tests.integration.routes import get_test_bot
+
 
 def test_get_bot_ims(internal_client: Client, mocker: MockerFixture):
     get_ims = mocker.patch("omnibot.services.slack.get_ims")
@@ -28,3 +30,4 @@ def test_get_bot_ims(internal_client: Client, mocker: MockerFixture):
     )
     assert resp.status_code == 200
     assert resp.json == {"ims": [mock_im]}
+    get_ims.assert_called_once_with(get_test_bot())

--- a/tests/integration/routes/test_get_ims.py
+++ b/tests/integration/routes/test_get_ims.py
@@ -1,0 +1,30 @@
+import json
+
+from flask import Response  # noqa: F401
+from pytest_mock import MockerFixture
+from werkzeug.test import Client
+
+
+def test_get_bot_ims(internal_client: Client, mocker: MockerFixture):
+    get_ims = mocker.patch("omnibot.services.slack.get_ims")
+    mock_im = {
+        "id": "TEST_IM_ID",
+        "created": 0,
+        "is_im": True,
+        "is_org_shared": True,
+        "user": "TEST_USER_ID",
+        "is_user_deleted": False,
+        "priority": 0,
+    }
+    mock_ims_value = [
+        (
+            "TEST_IM_ID",
+            json.dumps(mock_im),
+        )
+    ]
+    get_ims.return_value = mock_ims_value
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_ims/test-team-name/TEST_OMNIBOT_NAME"
+    )
+    assert resp.status_code == 200
+    assert resp.json == {"ims": [mock_im]}

--- a/tests/integration/routes/test_get_team.py
+++ b/tests/integration/routes/test_get_team.py
@@ -1,0 +1,16 @@
+from flask import Response  # noqa: F401
+from werkzeug.test import Client
+
+
+def test_get_team_id_by_name(internal_client: Client):
+    resp: Response = internal_client.get("/api/v1/slack/get_team/test-team-name")
+    assert resp.status_code == 200
+    assert resp.json["team_id"] == "TEST_TEAM_ID"
+
+
+def test_get_team_id_by_name_invalid(internal_client: Client):
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_team/test-invalid-team-name"
+    )
+    assert resp.status_code == 404
+    assert resp.json["error"] == "provided team_name is not configured."

--- a/tests/integration/routes/test_get_user_v2.py
+++ b/tests/integration/routes/test_get_user_v2.py
@@ -2,6 +2,8 @@ from flask import Response  # noqa: F401
 from pytest_mock import MockerFixture
 from werkzeug.test import Client
 
+from tests.integration.routes import get_test_bot
+
 
 def test_get_user_v2_user_found(internal_client: Client, mocker: MockerFixture):
     get_user_by_email = mocker.patch("omnibot.services.slack.get_user_by_email")
@@ -18,6 +20,7 @@ def test_get_user_v2_user_found(internal_client: Client, mocker: MockerFixture):
     assert user_resp["name"] == "testuser"
     assert user_resp["team_id"] == "TEST_TEAM_ID"
     assert user_resp["user_id"] == "test_user_id"
+    get_user_by_email.assert_called_once_with(get_test_bot(), "testuser@test.com")
 
 
 def test_get_user_v2_user_not_found(internal_client: Client, mocker: MockerFixture):
@@ -28,3 +31,4 @@ def test_get_user_v2_user_not_found(internal_client: Client, mocker: MockerFixtu
     )
     assert resp.status_code == 404
     assert resp.json["error"] == "user not found"
+    get_user_by_email.assert_called_once_with(get_test_bot(), "notauser@test.com")

--- a/tests/integration/routes/test_get_user_v2.py
+++ b/tests/integration/routes/test_get_user_v2.py
@@ -1,0 +1,30 @@
+from flask import Response  # noqa: F401
+from pytest_mock import MockerFixture
+from werkzeug.test import Client
+
+
+def test_get_user_v2_user_found(internal_client: Client, mocker: MockerFixture):
+    get_user_by_email = mocker.patch("omnibot.services.slack.get_user_by_email")
+    get_user_by_email.return_value = {
+        "profile": {"display_name": "testuser"},
+        "id": "test_user_id",
+    }
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_user/test-team-name/TEST_OMNIBOT_NAME/testuser@test.com"
+    )
+    assert resp.status_code == 200
+    user_resp = resp.json["user"]
+    assert user_resp["email"] == "testuser@test.com"
+    assert user_resp["name"] == "testuser"
+    assert user_resp["team_id"] == "TEST_TEAM_ID"
+    assert user_resp["user_id"] == "test_user_id"
+
+
+def test_get_user_v2_user_not_found(internal_client: Client, mocker: MockerFixture):
+    get_user_by_email = mocker.patch("omnibot.services.slack.get_user_by_email")
+    get_user_by_email.return_value = None
+    resp: Response = internal_client.get(
+        "/api/v1/slack/get_user/test-team-name/TEST_OMNIBOT_NAME/notauser@test.com"
+    )
+    assert resp.status_code == 404
+    assert resp.json["error"] == "user not found"

--- a/tests/integration/routes/test_interactive.py
+++ b/tests/integration/routes/test_interactive.py
@@ -144,8 +144,7 @@ def test_invalid_token(client: Client, queue: MagicMock, slack_api_call: MagicMo
         assert resp.json["status"] == "failure"
         assert (
             resp.json["error"]
-            == "Token sent with interactive component does not match any configured app."
-            # noqa: E501
+            == "Token sent with interactive component does not match any configured app."  # noqa: E501
         )
         queue.assert_not_called()
         slack_api_call.assert_not_called()
@@ -167,8 +166,7 @@ def test_invalid_callback_id(
         assert resp.json["response_type"] == "ephemeral"
         assert (
             resp.json["text"]
-            == "This interactive component does not have any omnibot handler associated with it."
-            # noqa: E501
+            == "This interactive component does not have any omnibot handler associated with it."  # noqa: E501
         )
         queue.assert_not_called()
         slack_api_call.assert_not_called()

--- a/tests/integration/routes/test_interactive.py
+++ b/tests/integration/routes/test_interactive.py
@@ -2,21 +2,13 @@ import json
 from typing import Any, Dict  # noqa: F401
 from unittest.mock import MagicMock
 
-import pytest
 from flask import Response  # noqa: F401
-from pytest_mock import MockerFixture
-from slackclient import SlackClient
 from werkzeug.test import Client
 
 from tests.data import get_mock_data
 from tests.integration.routes import get_test_bot
 
 _ENDPOINT = "/api/v1/slack/interactive"
-
-
-@pytest.fixture
-def slack_api_call(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch.object(SlackClient, "api_call")
 
 
 def test_dialog_submission_echo_test(
@@ -152,7 +144,8 @@ def test_invalid_token(client: Client, queue: MagicMock, slack_api_call: MagicMo
         assert resp.json["status"] == "failure"
         assert (
             resp.json["error"]
-            == "Token sent with interactive component does not match any configured app."  # noqa: E501
+            == "Token sent with interactive component does not match any configured app."
+            # noqa: E501
         )
         queue.assert_not_called()
         slack_api_call.assert_not_called()
@@ -174,7 +167,8 @@ def test_invalid_callback_id(
         assert resp.json["response_type"] == "ephemeral"
         assert (
             resp.json["text"]
-            == "This interactive component does not have any omnibot handler associated with it."  # noqa: E501
+            == "This interactive component does not have any omnibot handler associated with it."
+            # noqa: E501
         )
         queue.assert_not_called()
         slack_api_call.assert_not_called()

--- a/tests/integration/routes/test_send_im.py
+++ b/tests/integration/routes/test_send_im.py
@@ -1,0 +1,31 @@
+import json
+from unittest.mock import MagicMock
+
+from flask import Response  # noqa: F401
+from pytest_mock import MockerFixture
+from werkzeug.test import Client
+
+from tests.integration.routes import get_test_bot
+
+
+def test_send_bot_im(
+    internal_client: Client, mocker: MockerFixture, slack_api_call: MagicMock
+):
+    get_im_channel_id = mocker.patch("omnibot.services.slack.get_im_channel_id")
+    get_user_by_email = mocker.patch("omnibot.services.slack.get_user_by_email")
+    get_user_by_email.return_value = {"id": "TEST_USER_ID"}
+    get_im_channel_id.return_value = "TEST_CHANNEL_ID"
+    slack_api_call.return_value = {"ok": True}
+
+    resp: Response = internal_client.post(
+        "/api/v1/slack/send_im/test-team-name/TEST_OMNIBOT_NAME/testuser@example.com",
+        data=json.dumps({"action": "test-send-bot-im", "kwargs": {}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json == {"ok": True}
+    get_user_by_email.assert_called_once_with(get_test_bot(), "testuser@example.com")
+    get_im_channel_id.assert_called_once_with(get_test_bot(), "TEST_USER_ID")
+    slack_api_call.assert_called_once_with(
+        "test-send-bot-im", channel="TEST_CHANNEL_ID"
+    )

--- a/tests/integration/routes/test_slack_action.py
+++ b/tests/integration/routes/test_slack_action.py
@@ -1,0 +1,49 @@
+import json
+from unittest.mock import MagicMock
+
+from flask import Response  # noqa: F401
+from pytest_mock import MockerFixture
+from werkzeug.test import Client
+
+from tests.integration.routes import get_test_bot
+
+
+def test_slack_action(
+    internal_client: Client, mocker: MockerFixture, slack_api_call: MagicMock
+):
+    mock_channel_value = {"id": "TEST_CHANNEL_ID", "name": "test-channel"}
+
+    get_channel_by_name = mocker.patch("omnibot.services.slack.get_channel_by_name")
+    get_user_by_name = mocker.patch("omnibot.services.slack.get_user_by_name")
+    get_channel_by_name.return_value = mock_channel_value
+    get_user_by_name.return_value = {
+        "profile": {"display_name": "testuser"},
+        "id": "test_user_id",
+    }
+    slack_api_call.return_value = {"ok": True}
+
+    resp: Response = internal_client.post(
+        "/api/v2/slack/action/test-team-name/TEST_OMNIBOT_NAME",
+        data=json.dumps(
+            {
+                "action": "chat.postMessage",
+                "kwargs": {
+                    "channel": "TEST_CHANNEL_ID",
+                    "text": "@example see #general and use @here",
+                    "as_user": True,
+                    "omnibot_parse": {"text": ["channels", "users", "specials"]},
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json == {"ok": True}
+    get_channel_by_name.assert_called_once_with(get_test_bot(), "#general")
+    get_user_by_name.assert_called_once_with(get_test_bot(), "@example")
+    slack_api_call.assert_called_once_with(
+        "chat.postMessage",
+        channel="TEST_CHANNEL_ID",
+        text="<@test_user_id|testuser> see #general and use <!here|here>",
+        as_user=True,
+    )


### PR DESCRIPTION
https://jira.lyft.net/browse/INTPROD-5291

As part of the omnibot jailed test ticket, this is the second part of the PR that adds tests for the following endpoints:

/api/v1/slack/get_team/<team_name>
/api/v1/slack/get_user/<team_name>/<bot_name>/<email>
/api/v1/slack/get_channel/<team_name>/<bot_name>/<channel_name>
/api/v2/slack/action/<team_name>/<bot_name>
/api/v1/slack/get_ims/<team_name>/<bot_name>
/api/v1/slack/send_im/<team_name>/<bot_name>/<email>