### PR TITLE
fix watchers on elasticache clustered mode

### DIFF
--- a/omnibot/watcher.py
+++ b/omnibot/watcher.py
@@ -60,7 +60,7 @@ def watch_users():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_users',
+                '{watch_users}:watch_users',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.users'):
@@ -95,7 +95,7 @@ def watch_conversations():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_conversation',
+                '{watch_conversation}:watch_conversation',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.conversation'):
@@ -130,7 +130,7 @@ def watch_emoji():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_emoji',
+                '{watch_emoji}:watch_emoji',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.emoji'):

--- a/omnibot/watcher.py
+++ b/omnibot/watcher.py
@@ -60,6 +60,9 @@ def watch_users():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
+                # we prepend an elasticache {hash_key}
+                # to this and other redis locks
+                # so that they can function in clustered mode
                 '{watch_users}:watch_users',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):


### PR DESCRIPTION
Right now when omnibot is deployed with elasticache as its redis store configured in clustered mode the locks in [python-redis-lock](https://github.com/ionelmc/python-redis-lock) can fail because their keys can get hashed to different clusters, causing an error: 

```
redis.exceptions.ResponseError: CROSSSLOT Keys in request don't hash to the same slot
```

According to [AWS guidance on this error](https://aws.amazon.com/premiumsupport/knowledge-center/elasticache-crossslot-keys-error-redis/) you can force keys to be hashed to the same cluster by including a substring surrounded by `{braces}` such that only the text _inside_ the braces is used for hashing. This PR does exactly that on all of the Redis locks.

Note that this _is a breaking change_, and will, worst case, cause 2+ instances of a watcher to reindex users/conversations/emojis. That should be fine, though, as the data will become coherent again the next time it's reindexed.