### PR TITLE
[INTPROD-6007 Revert "fix watchers on elasticache clustered mode"

### DIFF
--- a/omnibot/watcher.py
+++ b/omnibot/watcher.py
@@ -60,10 +60,7 @@ def watch_users():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                # we prepend an elasticache {hash_key}
-                # to this and other redis locks
-                # so that they can function in clustered mode
-                '{watch_users}:watch_users',
+                'watch_users',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.users'):
@@ -98,7 +95,7 @@ def watch_conversations():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                '{watch_conversation}:watch_conversation',
+                'watch_conversation',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.conversation'):
@@ -133,7 +130,7 @@ def watch_emoji():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                '{watch_emoji}:watch_emoji',
+                'watch_emoji',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.emoji'):


### PR DESCRIPTION
Reverts lyft/omnibot#42 as a possible root cause for https://jira.lyft.net/browse/INTPROD-6007