### PR TITLE
[INTPROD-6007] Add team_id to users.list and conversations.list API call

### DIFF
--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -57,7 +57,7 @@ def _get_failure_context(result):
     return ret
 
 
-def _get_conversations(bot):
+def _get_conversations(bot, team):
     """
     Get all conversations
     """
@@ -70,7 +70,8 @@ def _get_conversations(bot):
             exclude_archived=True,
             exclude_members=True,
             limit=1000,
-            cursor=next_cursor
+            cursor=next_cursor,
+            team_id=team.team_id
         )
         if conversations_data['ok']:
             conversations.extend(conversations_data['channels'])
@@ -103,8 +104,8 @@ def _get_conversations(bot):
     return conversations
 
 
-def update_conversations(bot):
-    for conversation in _get_conversations(bot):
+def update_conversations(bot, team):
+    for conversation in _get_conversations(bot, team):
         if conversation.get('is_channel', False):
             update_channel(bot, conversation)
         elif conversation.get('is_group', False):
@@ -373,7 +374,7 @@ def get_channel_by_name(bot, channel):
     return None
 
 
-def _get_users(bot, max_retries=MAX_RETRIES, sleep=GEVENT_SLEEP_TIME):
+def _get_users(bot, team, max_retries=MAX_RETRIES, sleep=GEVENT_SLEEP_TIME):
     users = []
     retry = 0
     next_cursor = ''
@@ -382,7 +383,8 @@ def _get_users(bot, max_retries=MAX_RETRIES, sleep=GEVENT_SLEEP_TIME):
             'users.list',
             presence=False,
             limit=1000,
-            cursor=next_cursor
+            cursor=next_cursor,
+            team_id=team.team_id
         )
         if users_data['ok']:
             users.extend(users_data['members'])
@@ -415,8 +417,8 @@ def _get_users(bot, max_retries=MAX_RETRIES, sleep=GEVENT_SLEEP_TIME):
     return users
 
 
-def update_users(bot):
-    for user in _get_users(bot):
+def update_users(bot, team):
+    for user in _get_users(bot, team):
         update_user(bot, user)
 
 

--- a/omnibot/watcher.py
+++ b/omnibot/watcher.py
@@ -60,7 +60,10 @@ def watch_users():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_users',
+                # we prepend an elasticache {hash_key}
+                # to this and other redis locks
+                # so that they can function in clustered mode
+                '{watch_users}:watch_users',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.users'):
@@ -95,7 +98,7 @@ def watch_conversations():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_conversation',
+                '{watch_conversation}:watch_conversation',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.conversation'):
@@ -130,7 +133,7 @@ def watch_emoji():
         statsd = stats.get_statsd_client()
         with redis_lock.Lock(
                 redis_client,
-                'watch_emoji',
+                '{watch_emoji}:watch_emoji',
                 expire=LOCK_EXPIRATION,
                 auto_renewal=True):
             with statsd.timer('watch.emoji'):

--- a/omnibot/watcher.py
+++ b/omnibot/watcher.py
@@ -71,7 +71,7 @@ def watch_users():
                     )
                     team = Team.get_team_by_name(team_name)
                     bot = Bot.get_bot_by_name(team, bot_name)
-                    slack.update_users(bot)
+                    slack.update_users(bot, team)
             redis_client.set(last_run_key, datetime.now().isoformat())
     except Exception:
         logger.exception(
@@ -106,7 +106,7 @@ def watch_conversations():
                     )
                     team = Team.get_team_by_name(team_name)
                     bot = Bot.get_bot_by_name(team, bot_name)
-                    slack.update_conversations(bot)
+                    slack.update_conversations(bot, team)
             redis_client.set(last_run_key, datetime.now().isoformat())
     except Exception:
         logger.exception(


### PR DESCRIPTION
Based on https://api.slack.com/methods/conversations.list and https://api.slack.com/methods/users.list, team_id is a required attribute if token belongs to org-wide app. This is to fix the miss_argument issue Omnibot has for users.list and conversations.list