### PR TITLE
[INTPROD-6007] Fix build induced by dependency updates

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -46,7 +46,7 @@ slackclient==1.0.7        # via -r requirements.in
 statsd==3.2.1             # via -r requirements.in
 toml==0.10.2              # via pytest
 typing-extensions==3.10.0.0  # via importlib-metadata
-urllib3==1.26.5           # via requests
+urllib3==1.25.3           # via requests
 websocket-client==0.56.0  # via slackclient
 werkzeug==0.15.5          # via flask
 zipp==3.4.1               # via importlib-metadata


### PR DESCRIPTION
ERROR: Cannot install -r ./docs/../requirements3.txt (line 42) and urllib3==1.26.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.22.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
