### PR TITLE
Add channel_not_found to user token retry

### DIFF
--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -711,7 +711,11 @@ def _perform_action(bot, data):
     )
     logger.debug(ret)
     if not ret['ok']:
-        if ret.get('error') in ['missing_scope', 'not_allowed_token_type']:
+        if ret.get('error') in [
+            'missing_scope',
+            'not_allowed_token_type',
+            'channel_not_found',
+        ]:
             logger.warning(
                 'action failed in post_slack, attempting as user.',
                 extra=merge_logging_context(


### PR DESCRIPTION
This will allow omnibot to retry on `channel_not_found` errors, which is useful for fetching conversation.history on public channels without the bot having to be invited to the channel.