### PR TITLE
Add not_in_channel to user token retry

### DIFF
--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -711,11 +711,12 @@ def _perform_action(bot, data):
     )
     logger.debug(ret)
     if not ret['ok']:
-        if ret.get('error') in [
+        if ret.get('error') in {
             'missing_scope',
             'not_allowed_token_type',
             'channel_not_found',
-        ]:
+            'not_in_channel',
+        }:
             logger.warning(
                 'action failed in post_slack, attempting as user.',
                 extra=merge_logging_context(


### PR DESCRIPTION
This will allow omnibot to retry on `not_in_channel` errors, which is useful for fetching conversation.history on public channels without the bot having to be invited to the channel.