### PR TITLE
Support view_submission interactive component type

### DIFF
--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -262,6 +262,7 @@ def slack_interactive_component():
             'message_action',
             'dialog_submission',
             'block_actions',
+            'view_submission',
         ]
     ):
         msg = ('Unsupported type={} in interactive'


### PR DESCRIPTION
Support `view_submission` as an interactive component type (i.e. [modal submission](https://api.slack.com/surfaces/modals/using#closing_views))