### PR TITLE
Update get_channel_by_name API response example 

### DIFF
--- a/omnibot/routes/api.py
+++ b/omnibot/routes/api.py
@@ -608,48 +608,46 @@ def get_channel_by_name(team_name, bot_name, channel_name):
        Content-Type: application/json
 
        {
-         "channel": {
-           "id": "C4VQ6NUNN",
-           "name": "general",
-           "is_channel": true,
-           "created": 1491515285,
-           "creator": "U4WF56QGP",
-           "is_archived": false,
-           "is_general": true,
-           "unlinked": 0,
-           "name_normalized": "general",
-           "is_shared": false,
-           "is_org_shared": false,
-           "is_member": false,
-           "is_private": false,
-           "is_mpim": false,
-           "members": [
-             "U4WF56QGP",
-             "U6HQQ19EC",
-             "U6J3LTKSQ",
-             "U6J4EGP44",
-             "U6JDF1JBU",
-             "U6JEGTFDZ",
-             "U6JERPMJ7",
-             "U6JG691MJ",
-             "U6JGEQ0J0",
-             "U6SAVUK44",
-             "U750C7B37",
-             "U7DH0H802"
-           ],
-           "topic": {
-             "value": "test123",
-             "creator": "U6J3LTKSQ",
-             "last_set": 1507156612
-           },
-           "purpose": {
-             "value": "This channel is for team-wide communication.",
-             "creator": "",
-             "last_set": 0
-           },
-           "previous_names": [],
-           "num_members": 9
-         }
+        "id": "C4VQ6NUNN",
+        "name": "general",
+        "is_channel": true,
+        "created": 1491515285,
+        "creator": "U4WF56QGP",
+        "is_archived": false,
+        "is_general": true,
+        "unlinked": 0,
+        "name_normalized": "general",
+        "is_shared": false,
+        "is_org_shared": false,
+        "is_member": false,
+        "is_private": false,
+        "is_mpim": false,
+        "members": [
+            "U4WF56QGP",
+            "U6HQQ19EC",
+            "U6J3LTKSQ",
+            "U6J4EGP44",
+            "U6JDF1JBU",
+            "U6JEGTFDZ",
+            "U6JERPMJ7",
+            "U6JG691MJ",
+            "U6JGEQ0J0",
+            "U6SAVUK44",
+            "U750C7B37",
+            "U7DH0H802"
+        ],
+        "topic": {
+            "value": "test123",
+            "creator": "U6J3LTKSQ",
+            "last_set": 1507156612
+        },
+        "purpose": {
+            "value": "This channel is for team-wide communication.",
+            "creator": "",
+            "last_set": 0
+        },
+        "previous_names": [],
+        "num_members": 9
       }
 
     :param team_name: The team to search for this channel, as configured in


### PR DESCRIPTION
PR updates the API response example for the get_channel_by_name API. 

The previous example shows the channel details is nested within a top level `channel` key but it isn't because when we save the info to the cache, we access what's at the `channel` key and save that object. https://github.com/lyft/omnibot/blob/b92f9fa125c4a20528d0f82607a2cc1380a8df2e/omnibot/services/slack/__init__.py#L309
