### PR TITLE
Ignore bot messages from slackbot user

### DIFF
--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -25,8 +25,8 @@ class Message:
         self._payload["team"] = {"name": bot.team.name, "team_id": bot.team.team_id}
         self._payload["ts"] = event["ts"]
         self._payload["thread_ts"] = event.get("thread_ts")
-        self._check_unsupported()
         self._payload["user"] = event.get("user")
+        self._check_unsupported()
         if self.user:
             self._payload["parsed_user"] = slack.get_user(self.bot, self.user)
         elif self.bot_id:
@@ -61,6 +61,10 @@ class Message:
         unsupported = False
         if self.bot_id:
             logger.debug("ignoring message from bot", extra=self.event_trace)
+            unsupported = True
+        # Ignore slackbot as it doesn't get classifed as a bot user
+        elif self.user and self.user == "USLACKBOT":
+            logger.debug("ignoring message from slackbot", extra=self.event_trace)
             unsupported = True
         # Ignore threads
         elif self.thread_ts:

--- a/tests/unit/omnibot/services/slack/message_test.py
+++ b/tests/unit/omnibot/services/slack/message_test.py
@@ -132,3 +132,8 @@ def test_message(mocker):
     event_copy["subtype"] = "some_subtype"
     with pytest.raises(MessageUnsupportedError):
         _message = Message(_bot, event_copy, event_trace)
+    
+    event_copy = copy.deepcopy(event)
+    event_copy["user"] = "USLACKBOT"
+    with pytest.raises(MessageUnsupportedError):
+        _message = Message(_bot, event_copy, event_trace)

--- a/tests/unit/omnibot/services/slack/message_test.py
+++ b/tests/unit/omnibot/services/slack/message_test.py
@@ -132,7 +132,7 @@ def test_message(mocker):
     event_copy["subtype"] = "some_subtype"
     with pytest.raises(MessageUnsupportedError):
         _message = Message(_bot, event_copy, event_trace)
-    
+
     event_copy = copy.deepcopy(event)
     event_copy["user"] = "USLACKBOT"
     with pytest.raises(MessageUnsupportedError):


### PR DESCRIPTION
On a few occasions our bot has received messages from `Slackbot`, which results in thousands of exchanges to our bot as it's interpreting Slakbot's message as a command request.

There's code in Omnibot to ignore messages from bots, and I originally thought there was a bug with this logic. https://github.com/lyft/omnibot/blob/60d042ec55295d139b92e29d737b4a4c9d1076a8/omnibot/services/slack/message.py#L58-L62

However, in inspecting Omnibot's message event to our bot, I noticed that in the `parsed_user` object, the `is_bot` field is `false`, which lead me to believe that Slack isn't classifying `Slackbot` as a bot user and not sending `bot_id`. Example:
```
"parsedUser": {
            "id": "USLACKBOT",
            "tz": "America/Los_Angeles",
            "name": "slackbot",
            "color": "757575",
            "is_bot": false,
            "deleted": false,
            "profile": {
                   ..
            },
         ...
        },
```

This is confirmed [in docs](https://api.slack.com/types/user)(search for `is_bot`) and in this [tweet](https://twitter.com/slackapi/status/938378388871499776?lang=gl) from Slack. PR adds a change to ignore messages from Slackbot, whose user id will always be `USLACKBOT`.