### PR TITLE
Revert "Bump urllib3 from 1.26.5 to 1.26.17 (#98)"

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -46,7 +46,7 @@ slackclient==1.0.7        # via -r requirements.in
 statsd==3.2.1             # via -r requirements.in
 toml==0.10.2              # via pytest
 typing-extensions==3.10.0.0  # via importlib-metadata
-urllib3==1.26.17           # via requests
+urllib3==1.26.5           # via requests
 websocket-client==0.56.0  # via slackclient
 werkzeug==0.15.5          # via flask
 zipp==3.4.1               # via importlib-metadata


### PR DESCRIPTION
This reverts commit f8e38437e2297a6a40145c33b094f004e192304b.