### PR TITLE
[INTPROD-9204] Allow Match By Bot User ID

### DIFF
--- a/docs/root/adding_new_slack_apps.rst
+++ b/docs/root/adding_new_slack_apps.rst
@@ -46,6 +46,12 @@ Adding normal slack apps
       * message.im
       * message.mpim
 
+      * Note 1: adding ``app_mention`` may result in your bot being called twice.
+      * Note 2: the configuration `bot.name` for your bot should match your app user_handle
+      * Note 3: if your app user_handle does not match your `bot.name` you need to
+        specify `match_mention: true` to receive callbacks
+
+
 #. Add interactive component configuration (if the bot needs interactive components), using the ``Interactive Components`` link in the sidebar:
 
    #. Add the request URL. This will be the interactibe API route; so, if your omnibot hostname is ``omnibot.example.com``, the URL would be ``https://omnibot.example.com/api/v1/slack/interactive``. Slack will not verify this URL, unfortunately.

--- a/docs/root/adding_new_slack_apps.rst
+++ b/docs/root/adding_new_slack_apps.rst
@@ -45,7 +45,7 @@ Adding normal slack apps
       * message.groups
       * message.im
       * message.mpim
-
+   #.
       * Note 1: adding ``app_mention`` may result in your bot being called twice.
       * Note 2: the configuration `bot.name` for your bot should match your app user_handle
       * Note 3: if your app user_handle does not match your `bot.name` you need to

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -471,7 +471,7 @@ def get_user(bot, user_id):
             ),
         )
         return {}
-    
+
 
 def get_auth(bot):
     """

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -471,6 +471,29 @@ def get_user(bot, user_id):
             ),
         )
         return {}
+    
+
+def get_auth(bot):
+    """
+    Get the auth info for the bot.
+    """
+    redis_client = omniredis.get_redis_client()
+    auth_info = redis_client.hget(f"auth:{bot.team.name}", bot.name)
+    if auth_info:
+        return json.loads(auth_info)
+    auth_info = client(bot).api_call("auth.test")
+    if auth_info["ok"]:
+        redis_client.hset(f"auth:{bot.team.name}", bot.id, json.dumps(auth_info))
+        return auth_info
+    else:
+        logger.warning(
+            "Failed to get auth info",
+            extra=merge_logging_context(
+                _get_failure_context(auth_info),
+                bot.logging_context,
+            ),
+        )
+        return {}
 
 
 def get_auth(bot):

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -496,29 +496,6 @@ def get_auth(bot):
         return {}
 
 
-def get_auth(bot):
-    """
-    Get the auth info for the bot.
-    """
-    redis_client = omniredis.get_redis_client()
-    auth_info = redis_client.hget(f"auth:{bot.team.name}", bot.name)
-    if auth_info:
-        return json.loads(auth_info)
-    auth_info = client(bot).api_call("auth.test")
-    if auth_info["ok"]:
-        redis_client.hset(f"auth:{bot.team.name}", bot.name, json.dumps(auth_info))
-        return auth_info
-    else:
-        logger.warning(
-            "Failed to get auth info",
-            extra=merge_logging_context(
-                _get_failure_context(auth_info),
-                bot.logging_context,
-            ),
-        )
-        return {}
-
-
 def get_name_from_user(user):
     profile = user.get("profile", {})
     name = profile.get("display_name")

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -483,7 +483,7 @@ def get_auth(bot):
         return json.loads(auth_info)
     auth_info = client(bot).api_call("auth.test")
     if auth_info["ok"]:
-        redis_client.hset(f"auth:{bot.team.name}", bot.id, json.dumps(auth_info))
+        redis_client.hset(f"auth:{bot.team.name}", bot.name, json.dumps(auth_info))
         return auth_info
     else:
         logger.warning(

--- a/omnibot/services/slack/bot.py
+++ b/omnibot/services/slack/bot.py
@@ -1,4 +1,5 @@
 from omnibot import settings
+from omnibot.services.slack import get_auth
 from omnibot.services.slack.team import Team
 from omnibot.utils import merge_logging_context
 
@@ -82,6 +83,15 @@ class Bot:
     @property
     def bot_id(self):
         return self._bot_data.get("app_id")
+    
+    @property
+    def user_id(self):
+        user_id = self._bot_data.get("user_id")
+        if not user_id:
+            user_id = get_auth(self).get("user_id")
+            if user_id:
+                self._bot_data["user_id"] = user_id
+        return user_id
 
     @property
     def verification_token(self):

--- a/omnibot/services/slack/bot.py
+++ b/omnibot/services/slack/bot.py
@@ -83,7 +83,7 @@ class Bot:
     @property
     def bot_id(self):
         return self._bot_data.get("app_id")
-    
+
     @property
     def user_id(self):
         user_id = self._bot_data.get("user_id")

--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -176,7 +176,7 @@ class Message:
                 extra=self.event_trace,
             )
         self._payload["mentioned"] = False
-        for _, user_name in self.users.items():
+        for user_id, user_name in self.users.items():
             if self.bot.name == user_name:
                 self._payload["mentioned"] = True
             if self.bot.user_id == f"<@{user_id}>":

--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -179,6 +179,8 @@ class Message:
         for _, user_name in self.users.items():
             if self.bot.name == user_name:
                 self._payload["mentioned"] = True
+            if self.bot.user_id == f"<@{user_id}>":
+                self._payload["mentioned"] = True
         try:
             self._payload["command_text"] = parser.extract_command(
                 # Similar to mentions above, we find the command text

--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -179,7 +179,7 @@ class Message:
         for user_id, user_name in self.users.items():
             if self.bot.name == user_name:
                 self._payload["mentioned"] = True
-            if self.bot.user_id == f"<@{user_id}>":
+            if f"<@{self.bot.user_id}>" == user_id:
                 self._payload["mentioned"] = True
         try:
             self._payload["command_text"] = parser.extract_command(

--- a/tests/unit/omnibot/services/slack/message_test.py
+++ b/tests/unit/omnibot/services/slack/message_test.py
@@ -11,6 +11,7 @@ from omnibot.services.slack.team import Team
 def test_message(mocker):
     _team = Team.get_team_by_name("testteam")
     _bot = Bot.get_bot_by_name(_team, "echobot")
+    _bot._bot_data["user_id"] = "A12345678"
     event = {
         "ts": "1234567.12",
         "thread_ts": None,


### PR DESCRIPTION
This pull request includes changes to the `omnibot` service and its documentation. The changes mainly revolve around the addition of a `user_id` property in the `Bot` class, the modification of the `_parse_payload` method in the `Message` class to include a check for the bot's `user_id`, and the addition of important notes in the `Adding normal slack apps` documentation.

Documentation Updates:

* [`docs/root/adding_new_slack_apps.rst`](diffhunk://#diff-31bdebcf2f1187f82ac5efc676dd93fb8c7c5f4ee85b81f7fc486a6ef543c9deR48-R53): Added notes about the potential for the bot to be called twice if `app_mention` is added, the need for `bot.name` to match the app `user_handle`, and the need to specify `match_mention: true` if `user_handle` and `bot.name` do not match.

Codebase Updates:

* [`omnibot/services/slack/bot.py`](diffhunk://#diff-4050ebc6feafe8ceb1145ae4c7149d83a181f55dc32c75e79525a8a5709ac785R2): Imported `get_auth` from `omnibot.services.slack` and added a `user_id` property to the `Bot` class that fetches the `user_id` from `bot_data` or calls `get_auth` if `user_id` is not present. [[1]](diffhunk://#diff-4050ebc6feafe8ceb1145ae4c7149d83a181f55dc32c75e79525a8a5709ac785R2) [[2]](diffhunk://#diff-4050ebc6feafe8ceb1145ae4c7149d83a181f55dc32c75e79525a8a5709ac785R87-R95)
* [`omnibot/services/slack/message.py`](diffhunk://#diff-76d2c4d8159d285244ea3ee98f6d2acde313fc5413b55106384fea03f1bf184dL179-R183): Modified the `_parse_payload` method to check if the bot's `user_id` is mentioned in the message.
* [`tests/unit/omnibot/services/slack/message_test.py`](diffhunk://#diff-f42e42442277bcdb393292670d558e99345a87f55f76ce133bc0842ce05f514aR14): Updated the test setup to include a `user_id` in the bot's data.