### PR TITLE
[INTPROD-9204] Add Auth-Test Call

### DIFF
--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -471,6 +471,30 @@ def get_user(bot, user_id):
             ),
         )
         return {}
+    
+
+
+def get_auth(bot):
+    """
+    Get the auth info for the bot.
+    """
+    redis_client = omniredis.get_redis_client()
+    auth_info = redis_client.hget(f"auth:{bot.team.name}", bot.name)
+    if auth_info:
+        return json.loads(auth_info)
+    auth_info = client(bot).api_call("auth.test")
+    if auth_info["ok"]:
+        redis_client.hset(f"auth:{bot.team.name}", bot.id, json.dumps(auth_info))
+        return auth_info
+    else:
+        logger.warning(
+            "Failed to get auth info",
+            extra=merge_logging_context(
+                _get_failure_context(auth_info),
+                bot.logging_context,
+            ),
+        )
+        return {}
 
 
 def get_name_from_user(user):

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -471,7 +471,6 @@ def get_user(bot, user_id):
             ),
         )
         return {}
-    
 
 
 def get_auth(bot):

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -483,7 +483,7 @@ def get_auth(bot):
         return json.loads(auth_info)
     auth_info = client(bot).api_call("auth.test")
     if auth_info["ok"]:
-        redis_client.hset(f"auth:{bot.team.name}", bot.id, json.dumps(auth_info))
+        redis_client.hset(f"auth:{bot.team.name}", bot.name, json.dumps(auth_info))
         return auth_info
     else:
         logger.warning(


### PR DESCRIPTION
This pull request includes a significant change to the `omnibot/services/slack/__init__.py` file. A new function `get_auth(bot)` has been added. This function retrieves the authentication information for the bot. If the authentication information is not found in the Redis client, it makes an API call to `auth.test`. If the API call is successful, the authentication information is stored in the Redis client for future use. If the API call fails, a warning is logged and an empty dictionary is returned.

* [`omnibot/services/slack/__init__.py`](diffhunk://#diff-54762f953f73c007a82df8f886ed4ae4e222223ed69f4f5b7b7988e38de5becbR476-R499): Added a new function `get_auth(bot)`. This function retrieves the bot's authentication information from the Redis client, or makes an API call to `auth.test` if the information is not found. The result of the API call is then stored in the Redis client. If the API call fails, a warning is logged and an empty dictionary is returned.