### PR TITLE
[INTPROD-9625] Add support for reaction slack events

### DIFF
--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -135,14 +135,14 @@ def _process_reaction_handlers(reaction: Reaction):
         message = get_message(bot, item_channel, item_ts)
         bot_info = get_bot_info(bot, message["bot_id"])
         if bot_info and bot_info["app_id"] == bot.bot_id:
-            print("reaction matched")
+            logger.debug("reaction matched")
             for callback in handler["callbacks"]:
                 _handle_reaction_callback(reaction, callback)
                 handler_called = True
     if handler_called:
         statsd.incr("event.handled")
     elif not handler_called:
-        print("no handler found")
+        logger.debug("no handler found")
         statsd.incr("event.ignored")
 
 

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -507,7 +507,8 @@ def _handle_reaction_callback(reaction, callback):
     for action in response.get("actions", []):
         if not isinstance(action, dict):
             logger.error(
-                "Action in response is not a dict.", extra=reaction.event_trace
+                "Action in response is not a dict.",
+                extra=reaction.event_trace,
             )
             continue
         logger.debug(

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -11,12 +11,15 @@ from omnibot import logging
 from omnibot import settings
 from omnibot.services import slack
 from omnibot.services import stats
-from omnibot.services.slack import parser, get_message, get_bot_info
+from omnibot.services.slack import get_bot_info
+from omnibot.services.slack import get_message
+from omnibot.services.slack import parser
 from omnibot.services.slack.bot import Bot
 from omnibot.services.slack.interactive_component import InteractiveComponent
 from omnibot.services.slack.message import Message
 from omnibot.services.slack.message import MessageUnsupportedError
-from omnibot.services.slack.reaction import Reaction, ReactionUnsupportedError
+from omnibot.services.slack.reaction import Reaction
+from omnibot.services.slack.reaction import ReactionUnsupportedError
 from omnibot.services.slack.slash_command import SlashCommand
 from omnibot.services.slack.team import Team
 from omnibot.utils import get_callback_id
@@ -500,7 +503,9 @@ def _handle_reaction_callback(reaction, callback):
     response = _handle_callback(reaction, callback)
     for action in response.get("actions", []):
         if not isinstance(action, dict):
-            logger.error("Action in response is not a dict.", extra=reaction.event_trace)
+            logger.error(
+                "Action in response is not a dict.", extra=reaction.event_trace
+            )
             continue
         logger.debug(
             f"action for callback: {action}",

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -133,6 +133,9 @@ def _process_reaction_handlers(reaction: Reaction):
     for handler in bot.reaction_handlers:
         # Only match reactions against messages made by the bot
         message = get_message(bot, item_channel, item_ts)
+        if not message or "bot_id" not in message:
+            logger.warning("Failed to retrieve valid message or 'bot_id' is missing.")
+            continue
         bot_info = get_bot_info(bot, message["bot_id"])
         if bot_info and bot_info["app_id"] == bot.bot_id:
             logger.debug("reaction matched")

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -161,7 +161,7 @@ def _process_reaction_message_handlers(reaction: Reaction):
             # match. An unmatched regex should callback only if the regex is
             # not supposed to match.
             if match != regex_should_not_match:
-                reaction.set_match("regex", handler["match"])
+                reaction.set_match("reaction", handler["match"])
                 for callback in handler["callbacks"]:
                     _handle_message_callback(reaction, callback)
                     handler_called = True

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -126,7 +126,7 @@ def _process_reaction_message_handlers(reaction: Reaction):
 
     for handler in bot.message_handlers:
         if handler.get("match_type") == "reaction":
-            match = bool(re.search(handler["match"], reaction.reaction))
+            match = bool(re.fullmatch(handler["match"], reaction.reaction))
             regex_should_not_match = handler.get("regex_type") == "absence"
             # A matched regex should callback only if the regex is supposed to
             # match. An unmatched regex should callback only if the regex is

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -4,7 +4,8 @@ Core processing logic.
 import importlib
 import json
 import re
-from typing import Mapping, Any
+from typing import Any
+from typing import Mapping
 
 import requests
 

--- a/omnibot/services/slack/__init__.py
+++ b/omnibot/services/slack/__init__.py
@@ -386,7 +386,7 @@ def get_message(
 
 def get_bot_info(
     bot,
-    bot_id: str
+    bot_id: str,
 ):
     """
     Get bot info, from its bot id

--- a/omnibot/services/slack/base_message.py
+++ b/omnibot/services/slack/base_message.py
@@ -36,7 +36,6 @@ class BaseMessage:
             self._payload["parsed_user"] = None
         else:
             self._payload["parsed_user"] = None
-        self._payload["type"] = event["type"]
 
     @property
     def bot(self):
@@ -104,5 +103,5 @@ class BaseMessage:
         if match_type == "command":
             self._payload["command"] = match
             self._payload["args"] = self.command_text[len(match):].strip()  # fmt: skip
-        elif match_type == "regex":
+        elif match_type == "regex" or match_type == "reaction":
             self._payload["regex"] = match

--- a/omnibot/services/slack/base_message.py
+++ b/omnibot/services/slack/base_message.py
@@ -7,10 +7,16 @@ logger = logging.getLogger(__name__)
 
 class BaseMessage:
     """
-        Base class for representing a parsed slack event message.
+    Base class for representing a parsed slack event message.
     """
 
-    def __init__(self, bot: Bot, event: dict, event_trace: dict, omnibot_payload_type: str):
+    def __init__(
+        self,
+        bot: Bot,
+        event: dict,
+        event_trace: dict,
+        omnibot_payload_type: str,
+    ):
         self._event_trace = event_trace
         self.event = event
         self._match = None
@@ -22,7 +28,6 @@ class BaseMessage:
         self._payload["bot"] = {"name": bot.name, "bot_id": bot.bot_id}
         # For future safety sake, we'll do the same for the team.
         self._payload["team"] = {"name": bot.team.name, "team_id": bot.team.team_id}
-        self._payload["ts"] = event["event_ts"]
         self._payload["user"] = event.get("user")
         if self.user:
             self._payload["parsed_user"] = slack.get_user(self.bot, self.user)

--- a/omnibot/services/slack/base_message.py
+++ b/omnibot/services/slack/base_message.py
@@ -1,0 +1,103 @@
+from omnibot import logging
+from omnibot.services import slack
+from omnibot.services.slack.bot import Bot
+
+logger = logging.getLogger(__name__)
+
+
+class BaseMessage:
+    """
+        Base class for representing a parsed slack event message.
+    """
+
+    def __init__(self, bot: Bot, event: dict, event_trace: dict, omnibot_payload_type: str):
+        self._event_trace = event_trace
+        self.event = event
+        self._match = None
+        self._payload = {}
+        self._payload["omnibot_payload_type"] = omnibot_payload_type
+        self._bot = bot
+        # The bot object has data we don't want to pass to downstreams, so
+        # in the payload, we just store specific bot data.
+        self._payload["bot"] = {"name": bot.name, "bot_id": bot.bot_id}
+        # For future safety sake, we'll do the same for the team.
+        self._payload["team"] = {"name": bot.team.name, "team_id": bot.team.team_id}
+        self._payload["ts"] = event["event_ts"]
+        self._payload["user"] = event.get("user")
+        if self.user:
+            self._payload["parsed_user"] = slack.get_user(self.bot, self.user)
+        elif self.bot_id:
+            # TODO: call get_bot
+            self._payload["parsed_user"] = None
+        else:
+            self._payload["parsed_user"] = None
+        self._payload["type"] = event["type"]
+
+    @property
+    def bot(self):
+        """
+        The bot associated with the app that received this message from the
+        event subscription api. To get info about a bot that may have sent
+        this message, see bot_id.
+        """
+        return self._bot
+
+    @property
+    def bot_id(self):
+        """
+        The bot_id associated with the message, if the message if from a bot.
+        If this message isn't from a bot, this will return None.
+        """
+        return self.event.get("bot_id")
+
+    @property
+    def event_trace(self):
+        return self._event_trace
+
+    @property
+    def team(self):
+        return self._payload["team"]
+
+    @property
+    def payload(self):
+        return self._payload
+
+    @property
+    def user(self):
+        return self._payload["user"]
+
+    @property
+    def channel_id(self):
+        return self._payload.get("channel_id")
+
+    @property
+    def channel(self):
+        return self._payload.get("channel", {})
+
+    @property
+    def ts(self):
+        """
+        The timestamp of the event.
+        """
+        return self._payload["ts"]
+
+    @property
+    def match_type(self):
+        return self._payload.get("match_type")
+
+    @property
+    def match(self):
+        return self._match
+
+    @property
+    def command_text(self):
+        return self._payload.get("command_text")
+
+    def set_match(self, match_type: str, match: str):
+        self._payload["match_type"] = match_type
+        self._match = match
+        if match_type == "command":
+            self._payload["command"] = match
+            self._payload["args"] = self.command_text[len(match):].strip()  # fmt: skip
+        elif match_type == "regex":
+            self._payload["regex"] = match

--- a/omnibot/services/slack/bot.py
+++ b/omnibot/services/slack/bot.py
@@ -16,6 +16,7 @@ class Bot:
         self._interactive_component_handlers = []
         self._slash_command_handlers = []
         self._message_handlers = []
+        self._reaction_handlers = []
         self._configure_handlers()
 
     def _configure_handlers(self):
@@ -32,6 +33,10 @@ class Bot:
             bots = handler.get("bots", {}).get(self.team.name, {})
             if self.name in bots:
                 self._message_handlers.append(handler)
+        for handler in handlers.get("reaction_handlers", []):
+            bots = handler.get("bots", {}).get(self.team.name, {})
+            if self.name in bots:
+                self._reaction_handlers.append(handler)
 
     @classmethod
     def get_bot_by_name(cls, team, name):
@@ -125,6 +130,10 @@ class Bot:
     @property
     def message_handlers(self):
         return self._message_handlers
+
+    @property
+    def reaction_handlers(self):
+        return self._reaction_handlers
 
     @property
     def logging_context(self):

--- a/omnibot/services/slack/bot.py
+++ b/omnibot/services/slack/bot.py
@@ -16,7 +16,6 @@ class Bot:
         self._interactive_component_handlers = []
         self._slash_command_handlers = []
         self._message_handlers = []
-        self._reaction_handlers = []
         self._configure_handlers()
 
     def _configure_handlers(self):
@@ -33,10 +32,6 @@ class Bot:
             bots = handler.get("bots", {}).get(self.team.name, {})
             if self.name in bots:
                 self._message_handlers.append(handler)
-        for handler in handlers.get("reaction_handlers", []):
-            bots = handler.get("bots", {}).get(self.team.name, {})
-            if self.name in bots:
-                self._reaction_handlers.append(handler)
 
     @classmethod
     def get_bot_by_name(cls, team, name):
@@ -130,10 +125,6 @@ class Bot:
     @property
     def message_handlers(self):
         return self._message_handlers
-
-    @property
-    def reaction_handlers(self):
-        return self._reaction_handlers
 
     @property
     def logging_context(self):

--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -15,6 +15,8 @@ class Message(BaseMessage):
 
     def __init__(self, bot: Bot, event: dict, event_trace: dict):
         super().__init__(bot, event, event_trace, "message")
+        self._payload["ts"] = event["ts"]
+        self._payload["thread_ts"] = event.get("thread_ts")
         self._check_unsupported()
         try:
             self._payload["text"] = event["text"]

--- a/omnibot/services/slack/reaction.py
+++ b/omnibot/services/slack/reaction.py
@@ -15,6 +15,7 @@ class Reaction(BaseMessage):
         # `bot` is the receiving bot instance handling this reaction event,
         # not the user or bot who sent the reaction.
         super().__init__(bot, event, event_trace, "reaction")
+        self._payload["ts"] = event["event_ts"]
         self._check_unsupported()
         try:
             self._payload["reaction"] = event["reaction"]

--- a/omnibot/services/slack/reaction.py
+++ b/omnibot/services/slack/reaction.py
@@ -68,7 +68,6 @@ class Reaction:
                 extra=self.event_trace,
             )
 
-
     def _check_unsupported(self):
         # TODO: make the ignores configurable, but have a default list
         # Ignore self

--- a/omnibot/services/slack/reaction.py
+++ b/omnibot/services/slack/reaction.py
@@ -1,0 +1,144 @@
+from omnibot import logging
+from omnibot.services import slack
+from omnibot.services import stats
+
+logger = logging.getLogger(__name__)
+
+
+class Reaction:
+    """
+    Class for representing a parsed slack reaction.
+    """
+
+    def __init__(self, bot, event, event_trace):
+        self._event_trace = event_trace
+        self.event = event
+        self._match = None
+        self._payload = {}
+        self._payload["omnibot_payload_type"] = "reaction"
+        self._bot = bot
+        # The bot object has data we don't want to pass to downstreams, so
+        # in the payload, we just store specific bot data.
+        self._payload["bot"] = {"name": bot.name, "bot_id": bot.bot_id}
+        # For future safety sake, we'll do the same for the team.
+        self._payload["team"] = {"name": bot.team.name, "team_id": bot.team.team_id}
+        self._payload["ts"] = event["event_ts"]
+        self._payload["user"] = event.get("user")
+        self._check_unsupported()
+        if self.user:
+            self._payload["parsed_user"] = slack.get_user(self.bot, self.user)
+        elif self.bot_id:
+            # TODO: call get_bot
+            self._payload["parsed_user"] = None
+        else:
+            self._payload["parsed_user"] = None
+        self._payload["type"] = event["type"]
+        try:
+            self._payload["reaction"] = event["reaction"]
+        except Exception:
+            logger.error(
+                "Reaction event is missing reaction attribute.",
+                extra=self.event_trace,
+            )
+            raise
+        try:
+            self._payload["reaction"] = event["reaction"]
+        except Exception:
+            logger.error(
+                "Reaction event is missing reaction attribute.",
+                extra=self.event_trace,
+            )
+            raise
+        try:
+            self._payload["item_type"] = event["item"]["type"]
+            self._payload["item_channel"] = event["item"]["channel"]
+            self._payload["item_ts"] = event["item"]["ts"]
+        except Exception:
+            logger.error(
+                "Reaction event is missing a item attribute.",
+                extra=self.event_trace,
+            )
+            raise
+        self._payload["channel_id"] = event["item"]["channel"]
+        self._event_trace["channel_id"] = self.channel_id
+        self._payload["channel"] = slack.get_channel(self.bot, self.channel_id)
+        if not self.channel:
+            logger.error(
+                "Failed to fetch channel from channel_id.",
+                extra=self.event_trace,
+            )
+
+
+    def _check_unsupported(self):
+        # TODO: make the ignores configurable, but have a default list
+        # Ignore self
+        # Ignore bots
+        unsupported = False
+        if self.bot_id:
+            logger.debug("ignoring reaction from bot", extra=self.event_trace)
+            unsupported = True
+        # Ignore slackbot as it doesn't get classified as a bot user
+        elif self.user and self.user == "USLACKBOT":
+            logger.debug("ignoring reaction from slackbot", extra=self.event_trace)
+            unsupported = True
+        if unsupported:
+            statsd = stats.get_statsd_client()
+            statsd.incr("event.unsupported")
+            raise ReactionUnsupportedError()
+
+    @property
+    def channel_id(self):
+        return self._payload.get("channel_id")
+
+    @property
+    def channel(self):
+        return self._payload.get("channel", {})
+
+    @property
+    def user(self):
+        return self._payload["user"]
+
+    @property
+    def ts(self):
+        return self._payload["ts"]
+
+    @property
+    def bot(self):
+        """
+        The bot associated with the app that received this reaction from the
+        event subscription api. To get info about a bot that may have sent
+        this reaction, see bot_id.
+        """
+        return self._bot
+
+    @property
+    def bot_id(self):
+        """
+        The bot_id associated with the reaction, if the reaction is from a bot.
+        If this reaction isn't from a bot, this will return None.
+        """
+        return self.event.get("bot_id")
+
+    @property
+    def payload(self):
+        return self._payload
+
+    @property
+    def event_trace(self):
+        return self._event_trace
+
+    @property
+    def item_type(self):
+        return self._payload["item_type"]
+
+    @property
+    def item_channel(self):
+        return self._payload["item_channel"]
+
+    @property
+    def item_ts(self):
+        return self._payload["item_ts"]
+
+
+class ReactionUnsupportedError(Exception):
+    pass


### PR DESCRIPTION
Adds support for reaction slack events. 

For now, reaction handlers will only do callbacks if the reaction is on a matching bot slack message.

- Reaction Event Processing: Added logic to process reaction_added and reaction_removed events in omnibot/processor.py.
- New Reaction Class: Created a Reaction class omnibot/services/slack/reaction.py to encapsulate reaction event data and provide helper methods.
- Redis Caching: Utilized Redis to fetch and cache messages and bot information for efficient reaction processing.
- Bot Configuration: Updated omnibot/services/slack/bot.py to support reaction handlers.
- Moved common elements to a BaseMessage class for message and reaction
- Added new `reaction` `match_type` that will match against regex of emoji names