### PR TITLE
[INTPROD-9643] Add thread support for reaction message handlers

### DIFF
--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -152,11 +152,10 @@ def _process_reaction_message_handlers(reaction: Reaction):
     item_user = reaction.item_user
 
     if item_user is not None:
-        # Reaction is on a thread reply
         if item_user != bot.user_id:
             statsd.incr("event.ignored")
             return
-    elif not _is_message_from_bot(bot, item_channel, item_ts):
+    elif not _is_message_from_bot(bot, item_channel, item_ts):  # Fallback check
         statsd.incr("event.ignored")
         return
 

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -151,7 +151,7 @@ def _process_reaction_message_handlers(reaction: Reaction):
     item_ts = reaction.item_ts
     item_user = reaction.item_user
 
-    if item_user:
+    if item_user is not None:
         # Reaction is on a thread reply
         if item_user != bot.user_id:
             statsd.incr("event.ignored")

--- a/omnibot/services/slack/reaction.py
+++ b/omnibot/services/slack/reaction.py
@@ -21,7 +21,7 @@ class Reaction(BaseMessage):
             self._payload["emoji_name"] = event["reaction"]
         except Exception:
             logger.error(
-                "Reaction event is missing reaction attribute.",
+                "Reaction event is missing reaction attribute",
                 extra=self.event_trace,
             )
             raise
@@ -31,10 +31,11 @@ class Reaction(BaseMessage):
             self._payload["item_ts"] = event["item"]["ts"]
         except Exception:
             logger.error(
-                "Reaction event is missing a item attribute.",
+                "Reaction event is missing item attribute",
                 extra=self.event_trace,
             )
             raise
+        self._payload["item_user"] = event.get("item_user")
         self._payload["channel_id"] = self.item_channel
 
     def _check_unsupported(self):
@@ -74,6 +75,14 @@ class Reaction(BaseMessage):
         The timestamp of the item (e.g. "message", "file", etc.) that was reacted to.
         """
         return self._payload["item_ts"]
+
+    @property
+    def item_user(self):
+        """
+        The user who created the item (e.g. "message", "file", etc.) that was reacted to.
+        This is only present if the item is a thread reply.
+        """
+        return self._payload["item_user"]
 
     @property
     def emoji_name(self):

--- a/omnibot/services/slack/reaction.py
+++ b/omnibot/services/slack/reaction.py
@@ -80,7 +80,7 @@ class Reaction(BaseMessage):
     def item_user(self):
         """
         The user who created the item (e.g. "message", "file", etc.) that was reacted to.
-        This is only present if the item is a thread reply.
+        This is not always present, such as in reaction events to slack command responses.
         """
         return self._payload["item_user"]
 


### PR DESCRIPTION
Adds support for reactions made on thread replies.

The `item_user` field is only present for reaction events on messages such as those made with `chat.postMessage`. Responses made through slack command responses look similar to messages but reactions events on them do not contain `item_user` field and require a fallback check to determine which bot sent the response.