### PR TITLE
[INTPROD-9686] Add threaded conversation support

### DIFF
--- a/docs/root/adding_new_slack_apps.rst
+++ b/docs/root/adding_new_slack_apps.rst
@@ -50,6 +50,8 @@ Adding normal slack apps
       * Note 2: the configuration `bot.name` for your bot should match your app user_handle
       * Note 3: if your app user_handle does not match your `bot.name` you need to
         specify `match_mention: true` to receive callbacks
+      * Note 4: if you want your app to handle thread replies, you need to
+        specify `match_reply: true` to receive callbacks
 
 
 #. Add interactive component configuration (if the bot needs interactive components), using the ``Interactive Components`` link in the sidebar:

--- a/omnibot/processor.py
+++ b/omnibot/processor.py
@@ -113,6 +113,9 @@ def _process_message_message_handlers(message: Message):
     command_matched = False
     handler_called = False
     for handler in bot.message_handlers:
+        # We only match replies if the handler is set to match them
+        if message.thread_ts and not handler.get("match_reply", False):
+            continue
         # We only match commands against directed messages
         if handler["match_type"] == "command":
             if not _should_handle_command(handler, message):

--- a/omnibot/services/slack/message.py
+++ b/omnibot/services/slack/message.py
@@ -17,6 +17,7 @@ class Message(BaseMessage):
         super().__init__(bot, event, event_trace, "message")
         self._payload["ts"] = event["ts"]
         self._payload["thread_ts"] = event.get("thread_ts")
+        self._payload["parent_user_id"] = event.get("parent_user_id")
         self._check_unsupported()
         try:
             self._payload["text"] = event["text"]
@@ -49,10 +50,6 @@ class Message(BaseMessage):
         # Ignore slackbot as it doesn't get classifed as a bot user
         elif self.user and self.user == "USLACKBOT":
             logger.debug("ignoring message from slackbot", extra=self.event_trace)
-            unsupported = True
-        # Ignore threads
-        elif self.thread_ts:
-            logger.debug("ignoring thread message", extra=self.event_trace)
             unsupported = True
         # For now, ignore all event subtypes
         elif self.subtype:
@@ -201,7 +198,18 @@ class Message(BaseMessage):
 
     @property
     def thread_ts(self):
+        """
+        The timestamp of the parent message, if this is a reply to a message.
+        :return:
+        """
         return self._payload["thread_ts"]
+
+    @property
+    def parent_user_id(self):
+        """
+        The user_id of the parent message, if this is a reply to a message.
+        """
+        return self._payload["parent_user_id"]
 
     @property
     def channels(self):

--- a/tests/unit/omnibot/services/slack/message_test.py
+++ b/tests/unit/omnibot/services/slack/message_test.py
@@ -125,11 +125,6 @@ def test_message(mocker):
         _message = Message(_bot, event_copy, event_trace)
 
     event_copy = copy.deepcopy(event)
-    event_copy["thread_ts"] = "1234568.00"
-    with pytest.raises(MessageUnsupportedError):
-        _message = Message(_bot, event_copy, event_trace)
-
-    event_copy = copy.deepcopy(event)
     event_copy["subtype"] = "some_subtype"
     with pytest.raises(MessageUnsupportedError):
         _message = Message(_bot, event_copy, event_trace)


### PR DESCRIPTION
This pull request introduces support for handling thread replies in Slack apps by adding new configuration options and updating the message processing logic. The changes ensure that thread replies can be properly matched and processed by handlers, while also improving the overall structure of the `SlackMessage` class.

### Enhancements for handling thread replies:

* **Documentation Update**: Added a note in `docs/root/adding_new_slack_apps.rst` to explain that setting `match_reply: true` is required for apps to handle thread replies.
* **Message Handler Logic**: Updated `_process_message_message_handlers` in `omnibot/processor.py` to skip processing thread replies unless the handler explicitly specifies `match_reply: true`.

### Updates to the `SlackMessage` class:

* **Payload Enhancements**: Added `parent_user_id` to the `_payload` dictionary in `omnibot/services/slack/message.py` to capture the user ID of the parent message in thread replies.
* **Removed Thread Ignoring Logic**: Removed the logic in `_check_unsupported` that previously ignored thread messages, allowing them to be processed.
* **New Properties**: Introduced `parent_user_id` and updated the `thread_ts` property in `omnibot/services/slack/message.py` to provide clearer access to thread-related metadata.